### PR TITLE
Improve tests

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+
+  // e.g., 'Gin and Tonic' => 'gin-and-tonic'
+  formatForUrl: function (str) {
+    return str
+      .toLowerCase()
+      .replace(/\s/g, '-') // spaces => hyphens
+      .replace(/[^A-Za-z0-9\-]/g, '') // strip everything that's not a space, a num, or a hyphen
+      .replace(/-{2,}/g, '-'); // strip multiple hyphens
+  }
+
+};

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
   },
   "homepage": "https://github.com/redfieldstefan/msv2",
   "dependencies": {
-    "body-parser": "^1.13.3",
-    "express": "^4.13.3",
-    "mongoose": "^4.1.5",
-    "underscore": "^1.8.3"
+    "body-parser": "1.13.3",
+    "express": "4.13.3",
+    "mongoose": "4.1.5",
+    "underscore": "1.8.3"
   },
   "devDependencies": {
-    "chai": "^3.2.0",
-    "chai-http": "^1.0.0"
+    "chai": "3.2.0",
+    "chai-http": "1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js",
+    "test_backend": "mocha test/server",
+    "test": "npm run test_backend",
+    "start": "node server/index",
     "db":"mongod --dbpath=./data"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test_backend": "mocha test/server",
     "test": "npm run test_backend",
     "start": "node server/index",
-    "db":"mongod --dbpath=./data"
+    "db": "mongod --dbpath=./data"
   },
   "repository": {
     "type": "git",
@@ -22,7 +22,8 @@
   "dependencies": {
     "body-parser": "^1.13.3",
     "express": "^4.13.3",
-    "mongoose": "^4.1.5"
+    "mongoose": "^4.1.5",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/routes/api.js
+++ b/routes/api.js
@@ -44,7 +44,7 @@ module.exports = function(app) {
   });
 
   app.get(COCKTAIL_URL + '/:id', function(req, res) {
-    Cocktail.find({_id: req.params.id}, function(err, dbRes) {
+    Cocktail.findOne({_id: req.params.id}, function(err, dbRes) {
       if(err) {
         console.log(err);
         return dbRes.status(500).json({msg: 'server error'});
@@ -54,13 +54,17 @@ module.exports = function(app) {
   });
 
   app.put(COCKTAIL_URL + '/:id', function(req, res) {
-    var updatedCocktail = _prepForDb(req.body);
-    Cocktail.update({_id: req.params.id}, updatedCocktail, function(err, dbRes) {
-      if(err) {
-        console.log(err);
-        return dbRes.status(500).json({msg: 'server error'});
-      }
-      return res.status(200).json({msg: 'Cocktail updated'});
+    var updatedDrink = _prepForDb(req.body);
+    Cocktail.findOneAndUpdate({ _id: req.params.id },
+      updatedDrink, {
+        new: true
+      },
+      function(err, dbResponse) {
+        if (err) {
+          console.log(err);
+          return dbRes.status(500).json({msg: 'server error'});
+        }
+        return res.status(200).json(dbResponse);
     });
   });
 

--- a/routes/api.js
+++ b/routes/api.js
@@ -2,22 +2,15 @@
 
 var Cocktail = require('../models/cocktail_model');
 var Ingredient = require('../models/ingredient_model');
+var utils = require('../common/utils');
 
 var COCKTAIL_URL = '/api/cocktails';
 var INGREDIENT_URL = '/api/ingredients';
 
-var _urlify = function(cocktailName) {
-  return cocktailName
-    .toLowerCase()
-    .replace(/\s/g, '-')
-    .replace(/[^A-Za-z0-9\-]/g, '')
-    .replace(/-{2,}/g, '-');
-};
-
 var _prepForDb = function(cocktail) {
   return {
     name: cocktail.name,
-    url: _urlify(cocktail.name),
+    url: utils.formatForUrl(cocktail.name),
     description: cocktail.description ?
       cocktail.description :
       '',

--- a/test/mock/cocktails.json
+++ b/test/mock/cocktails.json
@@ -1,0 +1,17 @@
+{
+  "fakeCocktail": {
+    "name": "Fake cocktail",
+    "ingredients": [
+      "gin",
+      "peanut butter"
+    ]
+  },
+  "updatedFakeCocktail": {
+    "name": "Updated fake cocktail",
+    "ingredients": [
+      "gin",
+      "peanut butter",
+      "jelly"
+    ]
+  }
+}

--- a/test/server/api.spec.js
+++ b/test/server/api.spec.js
@@ -23,6 +23,13 @@ var _alphabetizeArray = function (arr) {
     .sort();
 };
 
+// Confirms that an object has the properties expected of a cocktail
+var _isACocktail = function (obj) {
+  return obj.hasOwnProperty('name') &&
+    obj.hasOwnProperty('url') &&
+    obj.hasOwnProperty('ingredients');
+};
+
 describe('The cocktail API', function () {
 
   it('Can add a new cocktail', function (done) {
@@ -64,7 +71,21 @@ describe('The cocktail API', function () {
         expect(res.body.ingredients).to.deep.equal(expectedIngredients);
         done();
       });
-  })
+  });
+
+  it('Can get a list of cocktails', function (done) {
+    chai
+      .request(APP_PATH)
+      .get(API_BASE)
+
+      .end(function (err, res) {
+        expect(err).to.be.null;
+        expect(res).to.have.status(200);
+        expect(Array.isArray(res.body) && res.body.length > 0).to.be.true;
+        expect(_isACocktail(res.body[0])).to.be.true;
+        done();
+      });
+  });
 
   it('Can update a cocktail', function (done) {
     chai

--- a/test/server/api.spec.js
+++ b/test/server/api.spec.js
@@ -14,8 +14,14 @@ var API_BASE = '/api/cocktails/';
 var APP_PATH = 'http://localhost:' + serverConfig.port;
 var fakeCocktail = fakeCocktails.fakeCocktail;
 var updatedFakeCocktail = fakeCocktails.updatedFakeCocktail;
-
 var fakeCocktailId;
+
+// The db sorts ingredients (alphabetically), so the tests need to too
+var _alphabetizeArray = function (arr) {
+  return arr
+    .slice()
+    .sort();
+};
 
 describe('The cocktail API', function () {
 
@@ -28,9 +34,7 @@ describe('The cocktail API', function () {
       .end(function (err, res) {
         var expectedName = fakeCocktail.name;
         var expectedUrl = utils.formatForUrl(fakeCocktail.name);
-        var expectedIngredients = fakeCocktail.ingredients
-          .slice()
-          .sort(); // The db sorts ingredients (alphabetically)
+        var expectedIngredients = _alphabetizeArray(fakeCocktail.ingredients);
 
         expect(err).to.be.null;
         expect(res).to.have.status(200);
@@ -50,8 +54,14 @@ describe('The cocktail API', function () {
 
       .end(function (err, res) {
         var expectedName = fakeCocktail.name;
+        var expectedUrl = utils.formatForUrl(fakeCocktail.name);
+        var expectedIngredients = _alphabetizeArray(fakeCocktail.ingredients);
+
         expect(err).to.be.null;
+        expect(res).to.have.status(200);
         expect(res.body.name).to.equal(expectedName);
+        expect(res.body.url).to.equal(expectedUrl);
+        expect(res.body.ingredients).to.deep.equal(expectedIngredients);
         done();
       });
   })
@@ -65,9 +75,7 @@ describe('The cocktail API', function () {
       .end(function (err, res) {
         var expectedName = updatedFakeCocktail.name;
         var expectedUrl = utils.formatForUrl(updatedFakeCocktail.name);
-        var expectedIngredients = updatedFakeCocktail.ingredients
-          .slice()
-          .sort();
+        var expectedIngredients = _alphabetizeArray(updatedFakeCocktail.ingredients);
 
         expect(err).to.be.null;
         expect(res).to.have.status(200);

--- a/test/server/api.spec.js
+++ b/test/server/api.spec.js
@@ -5,27 +5,15 @@ var chaiHttp = require('chai-http');
 var expect = chai.expect;
 chai.use(chaiHttp);
 
+var fakeCocktails = require('../mock/cocktails');
 var serverConfig = require('../../server/config');
 var utils = require('../../common/utils');
 require('../../server/index'); // Side effect: starts server when tests run
 
 var API_BASE = '/api/cocktails/';
 var APP_PATH = 'http://localhost:' + serverConfig.port;
-var fakeCocktail = {
-  name: 'Fake cocktail',
-  ingredients: [
-    'gin',
-    'peanut butter'
-  ]
-};
-var updatedFakeCocktail = {
-  name: 'Updated fake cocktail',
-  ingredients: [
-    'gin',
-    'peanut butter',
-    'jelly'
-  ]
-};
+var fakeCocktail = fakeCocktails.fakeCocktail;
+var updatedFakeCocktail = fakeCocktails.updatedFakeCocktail;
 
 var fakeCocktailId;
 


### PR DESCRIPTION
This PR:
- Moves `urlify` into `common/utils#formatForUrl`, so we can reuse it in the specs (and maybe elsewhere)
- Adds a test for the GET route
- Updates the PUT test to match on name, URL, and ingredients
- Adds an `npm run test` task (and updates `npm run start` to point at `server/index`, not `server.js`)
- Moves the fake cocktails used in `test/server/api.spec` into `test/mock`, where we'll build more fake data

/cc @redfieldstefan 
