### PR TITLE
Improvement: Node 4.0.0 + server-side ES6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "0.12"
+  - "4.0.0"
 
 install:
   npm install

--- a/common/utils.js
+++ b/common/utils.js
@@ -3,7 +3,7 @@
 module.exports = {
 
   // e.g., 'Gin and Tonic' => 'gin-and-tonic'
-  formatForUrl: function (str) {
+  formatForUrl (str) {
     return str
       .toLowerCase()
       .replace(/\s/g, '-') // spaces => hyphens

--- a/eslintconfig/.eslintrc-server
+++ b/eslintconfig/.eslintrc-server
@@ -1,4 +1,8 @@
 ---
 extends:
-  - "defaults/configurations/walmart/es5-node"
+  - "defaults/configurations/walmart/es6-node"
   - ".eslintrc-base"
+
+rules:
+  strict: [0]
+  space-before-function-paren: [1, "always"]

--- a/models/cocktail-model.js
+++ b/models/cocktail-model.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var mongoose = require('mongoose');
+const mongoose = require('mongoose');
 
-var cocktailSchema = mongoose.Schema({
+const cocktailSchema = mongoose.Schema({
   name: String,
   url: String,
   description: String,

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,44 +1,34 @@
 'use strict';
 
-var apiConfig = require('../server/config').api;
-var COCKTAIL_PATH = apiConfig.base + apiConfig.cocktailPath;
-var dbOperations = require('../server/db-operations');
+const apiConfig = require('../server/config').api;
+const COCKTAIL_PATH = `${apiConfig.base}${apiConfig.cocktailPath}`;
+const dbOperations = require('../server/db-operations');
 
-module.exports = function (app) {
+module.exports = (app) => {
 
-  app.post(COCKTAIL_PATH, function (req, res) {
+  app.post(COCKTAIL_PATH, (req, res) => {
     dbOperations.createCocktail(req.body)
-      .then(function (dbRes) {
-        return res.status(200).json(dbRes);
-      });
+      .then((dbRes) => res.status(200).json(dbRes));
   });
 
-  app.get(COCKTAIL_PATH, function (req, res) {
+  app.get(COCKTAIL_PATH, (req, res) => {
     dbOperations.getAllCocktails()
-      .then(function (dbRes) {
-        return res.status(200).json(dbRes);
-      });
+      .then((dbRes) => res.status(200).json(dbRes));
   });
 
-  app.get(COCKTAIL_PATH + '/:id', function (req, res) {
+  app.get(`${COCKTAIL_PATH}/:id`, (req, res) => {
     dbOperations.getCocktail(req.params.id)
-      .then(function (dbRes) {
-        return res.status(200).json(dbRes);
-      });
+      .then((dbRes) => res.status(200).json(dbRes));
   });
 
-  app.put(COCKTAIL_PATH + '/:id', function (req, res) {
+  app.put(`${COCKTAIL_PATH}/:id`, (req, res) => {
     dbOperations.updateCocktail(req.params.id, req.body)
-      .then(function (dbRes) {
-        return res.status(200).json(dbRes);
-      });
+      .then((dbRes) => res.status(200).json(dbRes));
   });
 
-  app.delete(COCKTAIL_PATH + '/:id', function (req, res) {
+  app.delete(`${COCKTAIL_PATH}/:id`, (req, res) => {
     dbOperations.deleteCocktail(req.params.id)
-      .then(function () {
-        return res.status(200).json({ msg: 'Cocktail Deleted' });
-      });
+      .then(() => res.status(200).json({ msg: 'Cocktail Deleted' }));
   });
 
 };

--- a/routes/middleware.js
+++ b/routes/middleware.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var COCKTAIL_PATH = require('../server/config').api.cocktailPath;
-var dbOperations = require('../server/db-operations');
+const COCKTAIL_PATH = require('../server/config').api.cocktailPath;
+const dbOperations = require('../server/db-operations');
 
-module.exports = function (app) {
+module.exports = (app) => {
 
-  app.get(COCKTAIL_PATH + '/:id', function (req, res, next) {
+  app.get(`${COCKTAIL_PATH}/:id`, (req, res, next) => {
     dbOperations.getCocktail(req.params.id)
-      .then(function (dbRes) {
+      .then((dbRes) => {
         res.locals.msData = dbRes;
         next();
       });

--- a/routes/react-server-render.js
+++ b/routes/react-server-render.js
@@ -1,26 +1,26 @@
 'use strict';
 
-var Iso = require('iso');
-var React = require('react');
-var Router = require('react-router');
+const Iso = require('iso');
+const React = require('react');
+const Router = require('react-router');
 
-var alt = require('../alt');
-var clientRoutes = require('../client/routes.jsx');
+const alt = require('../alt');
+const clientRoutes = require('../client/routes.jsx');
 
-module.exports = function (app) {
+module.exports = (app) => {
 
   /**
    * Handler that intercepts all routes defined in `clientRoutes` and server-renders
    * the corresponding component with the db's `msData` as props
    */
 
-  app.use(function (req, res) {
-    var iso = new Iso();
-    var data = res.locals.msData || {};
+  app.use((req, res) => {
+    const iso = new Iso();
+    const data = res.locals.msData || {};
     alt.bootstrap(JSON.stringify(data));
 
-    Router.run(clientRoutes, req.url, function (Handler) {
-      var content = React.renderToString(
+    Router.run(clientRoutes, req.url, (Handler) => {
+      const content = React.renderToString(
         React.createElement(Handler, data)
       );
       iso.add(content, alt.flush());

--- a/server/config.json
+++ b/server/config.json
@@ -1,5 +1,8 @@
 {
   "port": 3000,
+  "db": {
+    "path": "mongodb://localhost/ms_dev"
+  },
   "api": {
     "base": "/api",
     "cocktailPath": "/cocktails"

--- a/server/db-operations.js
+++ b/server/db-operations.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var _ = require('underscore');
+const _ = require('underscore');
 
-var Cocktail = require('../models/cocktail-model');
-var utils = require('../common/utils');
+const Cocktail = require('../models/cocktail-model');
+const utils = require('../common/utils');
 
-var _prepForDb = function (cocktail) {
+const _prepForDb = (cocktail) => {
   return {
     name:         cocktail.name,
     url:          utils.formatForUrl(cocktail.name),
@@ -16,37 +16,29 @@ var _prepForDb = function (cocktail) {
 
 module.exports = {
 
-  createCocktail: function (cocktailBody) {
-    var cocktail = new Cocktail(_prepForDb(cocktailBody));
+  createCocktail (cocktailBody) {
+    const cocktail = new Cocktail(_prepForDb(cocktailBody));
     return cocktail.save()
-      .then(function (dbRes) {
-        return _.clone(dbRes);
-      });
+      .then((dbRes) => _.clone(dbRes));
   },
 
-  getCocktail: function (cocktailId) {
+  getCocktail (cocktailId) {
     return Cocktail.findOne({ _id: cocktailId })
-      .then(function (dbRes) {
-        return _.clone(dbRes);
-      });
+      .then((dbRes) => _.clone(dbRes));
   },
 
-  getAllCocktails: function () {
+  getAllCocktails () {
     return Cocktail.find({})
-      .then(function (dbRes) {
-        return _.clone(dbRes);
-      });
+      .then((dbRes) => _.clone(dbRes));
   },
 
-  updateCocktail: function (id, cocktailBody) {
-    var updatedCocktail = _prepForDb(cocktailBody);
+  updateCocktail (id, cocktailBody) {
+    const updatedCocktail = _prepForDb(cocktailBody);
     return Cocktail.findOneAndUpdate({ _id: id }, updatedCocktail, { new: true })
-      .then(function (dbRes) {
-        return _.clone(dbRes);
-      });
+      .then((dbRes) => _.clone(dbRes));
   },
 
-  deleteCocktail: function (id) {
+  deleteCocktail (id) {
     return Cocktail.remove({ _id: id });
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -2,17 +2,17 @@
 
 require('node-jsx-babel').install({ extension: '.jsx' });
 
-var bodyparser = require('body-parser');
-var express = require('express');
-var hbs = require('express-handlebars');
-var http = require('http');
-var mongoose = require('mongoose');
-var path = require('path');
+const bodyparser = require('body-parser');
+const express = require('express');
+const hbs = require('express-handlebars');
+const http = require('http');
+const mongoose = require('mongoose');
+const path = require('path');
 
-var serverConfig = require('./config');
+const serverConfig = require('./config');
 
-var app = express();
-var server = http.createServer(app);
+const app = express();
+const server = http.createServer(app);
 
 app.use(bodyparser.json());
 
@@ -24,11 +24,11 @@ require('../routes/api')(app);
 require('../routes/middleware')(app);
 require('../routes/react-server-render')(app);
 
-mongoose.connect(process.env.MONGOLAB_URI || 'mongodb://localhost/ms_dev');
+mongoose.connect(process.env.MONGOLAB_URI || serverConfig.db.path);
 
-var port = process.env.PORT || serverConfig.port;
+const port = process.env.PORT || serverConfig.port;
 
-server.listen(port, function () {
+server.listen(port, () => {
   /*eslint-disable no-console*/
   console.log('Server is listenin hard on port', port);
   /*eslint-enable no-console*/

--- a/test/server/api.spec.js
+++ b/test/server/api.spec.js
@@ -1,46 +1,46 @@
 'use strict';
 
-var _ = require('underscore');
-var chai = require('chai');
-var chaiHttp = require('chai-http');
-var expect = chai.expect;
+const _ = require('underscore');
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const expect = chai.expect;
 chai.use(chaiHttp);
 
-var fakeCocktails = require('../mock/cocktails');
-var serverConfig = require('../../server/config');
-var utils = require('../../common/utils');
+const fakeCocktails = require('../mock/cocktails');
+const serverConfig = require('../../server/config');
+const utils = require('../../common/utils');
 require('../../server/index'); // Side effect: starts server when tests run
 
-var APP_PATH = 'http://localhost:' + serverConfig.port;
-var COCKTAIL_PATH = serverConfig.api.base + serverConfig.api.cocktailPath + '/';
-var fakeCocktail = fakeCocktails.fakeCocktail;
-var updatedFakeCocktail = fakeCocktails.updatedFakeCocktail;
+const APP_PATH = `http:\/\/localhost:${serverConfig.port}`;
+const COCKTAIL_PATH = `${serverConfig.api.base}${serverConfig.api.cocktailPath}/`;
+const fakeCocktail = fakeCocktails.fakeCocktail;
+const updatedFakeCocktail = fakeCocktails.updatedFakeCocktail;
 
-var fakeCocktailId;
+let fakeCocktailId;
 
 // ----------------------------------------------------------------------------
 // Helpers
 // ----------------------------------------------------------------------------
 
 // The db sorts ingredients (alphabetically), so the tests need to too
-var _alphabetizeArray = function (arr) {
+const _alphabetizeArray = (arr) => {
   return arr
     .slice()
     .sort();
 };
 
 // Confirms that an object has the general properties expected of a cocktail
-var _hasShapeOfCocktail = function (obj) {
+const _hasShapeOfCocktail = (obj) => {
   return obj.hasOwnProperty('name') &&
     obj.hasOwnProperty('url') &&
     obj.hasOwnProperty('ingredients');
 };
 
 // Confirms that an object has the properties expected of a specific cocktail
-var _matchesCocktail = function (actual, expected) {
-  var expectedName = expected.name;
-  var expectedUrl = utils.formatForUrl(expected.name);
-  var expectedIngredients = _alphabetizeArray(expected.ingredients);
+const _matchesCocktail = (actual, expected) => {
+  const expectedName = expected.name;
+  const expectedUrl = utils.formatForUrl(expected.name);
+  const expectedIngredients = _alphabetizeArray(expected.ingredients);
 
   if (!_hasShapeOfCocktail(actual)) {
     return false;
@@ -52,15 +52,15 @@ var _matchesCocktail = function (actual, expected) {
 
 // ----------------------------------------------------------------------------
 
-describe('The cocktail API', function () {
+describe('The cocktail API', () => {
 
-  it('Can add a new cocktail', function (done) {
+  it('Can add a new cocktail', (done) => {
     chai
       .request(APP_PATH)
       .post(COCKTAIL_PATH)
       .send(fakeCocktail)
 
-      .end(function (err, res) {
+      .end((err, res) => {
         expect(err).to.be.null;
         expect(res).to.have.status(200);
         expect(_matchesCocktail(res.body, fakeCocktail)).to.be.true;
@@ -70,12 +70,12 @@ describe('The cocktail API', function () {
       });
   });
 
-  it('Can get a cocktail', function (done) {
+  it('Can get a cocktail', (done) => {
     chai
       .request(APP_PATH)
-      .get(COCKTAIL_PATH + fakeCocktailId)
+      .get(`${COCKTAIL_PATH}${fakeCocktailId}`)
 
-      .end(function (err, res) {
+      .end((err, res) => {
         expect(err).to.be.null;
         expect(res).to.have.status(200);
         expect(_matchesCocktail(res.body, fakeCocktail)).to.be.true;
@@ -83,12 +83,12 @@ describe('The cocktail API', function () {
       });
   });
 
-  it('Can get a list of cocktails', function (done) {
+  it('Can get a list of cocktails', (done) => {
     chai
       .request(APP_PATH)
       .get(COCKTAIL_PATH)
 
-      .end(function (err, res) {
+      .end((err, res) => {
         expect(err).to.be.null;
         expect(res).to.have.status(200);
         expect(Array.isArray(res.body) && res.body.length > 0).to.be.true;
@@ -97,13 +97,13 @@ describe('The cocktail API', function () {
       });
   });
 
-  it('Can update a cocktail', function (done) {
+  it('Can update a cocktail', (done) => {
     chai
       .request(APP_PATH)
-      .put(COCKTAIL_PATH + fakeCocktailId)
+      .put(`${COCKTAIL_PATH}${fakeCocktailId}`)
       .send(updatedFakeCocktail)
 
-      .end(function (err, res) {
+      .end((err, res) => {
         expect(err).to.be.null;
         expect(res).to.have.status(200);
         expect(_matchesCocktail(res.body, updatedFakeCocktail)).to.be.true;
@@ -111,12 +111,12 @@ describe('The cocktail API', function () {
       });
   });
 
-  it('Can delete a cocktail', function (done) {
+  it('Can delete a cocktail', (done) => {
     chai
       .request(APP_PATH)
-      .del(COCKTAIL_PATH + fakeCocktailId)
+      .del(`${COCKTAIL_PATH}${fakeCocktailId}`)
 
-      .end(function (err, res) {
+      .end((err, res) => {
         expect(err).to.be.null;
         expect(res.body.msg).to.equal('Cocktail Deleted');
         done();


### PR DESCRIPTION
Closes #15 

This updates the server to use Node 4.0.0 and (mostly) ES6. Now that ES6 Node is stable, we might as well switch over to it right away, while our server is still small enough for the change to be easy.

Notes:
- You'll need to upgrade your machine's Node to 4.0.0--`nvm` should do the trick, or (because my `nvm` was being weird) I followed the instructions [here](http://davidwalsh.name/upgrade-nodejs)
- I'll go through and annotate the diff with interesting ES6 stuff, plus point out the few places where we can't use ES6 yet.

/cc @redfieldstefan 
